### PR TITLE
Keep duration with nonexisting assertions as short as possible

### DIFF
--- a/src/main/groovy/com/github/fhermansson/gradle/assertj/plugin/AssertjGenerator.groovy
+++ b/src/main/groovy/com/github/fhermansson/gradle/assertj/plugin/AssertjGenerator.groovy
@@ -69,6 +69,8 @@ class AssertjGenerator implements Plugin<Project> {
             }
         }
 
+        projekt.tasks.cleanAssertions.mustRunAfter compileJava
+
         project.compileTestJava.dependsOn('generateAssertions')
         project.sourceSets.test.java.srcDirs += project.assertjGenerator.outputDir
     }


### PR DESCRIPTION
We are using IntelliJ without the Gradle plugin to compile our project during the development process. Therefore the builds using IntelliJ or Gradle are completly independent. 

When running ``gradlew check`` the plugin first deletes the generated assertions and waits for ``compileJava`` to complete before generating the new assertions. During this period the build in IntelliJ will fail because of the missing generated classes.

With this PR Gradle will run the tasks in a different order and not in parallel: ``compileJava -> cleanAssertions -> generateAssertions``. This keeps the period without generated sources as short as possible.